### PR TITLE
lcm: upgrade node version

### DIFF
--- a/.github/workflows/automatic-tests.yml
+++ b/.github/workflows/automatic-tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
     
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18 as compiler
+FROM node:22 as compiler
 ARG GITHUB_ACCESS_TOKEN
 WORKDIR /work
 COPY . ./
@@ -6,20 +6,20 @@ COPY deploy.npmrc .npmrc
 RUN yarn install && yarn build
 
 
-FROM node:18 as git-rev
+FROM node:22 as git-rev
 WORKDIR /work
 COPY .git .git
 RUN git rev-parse --short HEAD >  git_revision.txt
 
-FROM node:18-alpine	as optimizer
+FROM node:22-alpine	as optimizer
 ARG GITHUB_ACCESS_TOKEN
 WORKDIR /work
 COPY . ./
 COPY deploy.npmrc .npmrc
 RUN yarn install --production --ignore-optional --platform=linux --arch=x64
 
-#FROM gcr.io/distroless/nodejs18-debian11
-FROM node:18-alpine
+#FROM gcr.io/distroless/nodejs22-debian11
+FROM node:22-alpine
 EXPOSE 3000
 ENV NODE_ENV=production
 ENV PORT=3000
@@ -34,4 +34,3 @@ COPY --from=git-rev /work/git_revision.txt ./
 COPY --from=optimizer /work/docker-cmd-with-crond.sh ./
 
 CMD ["sh", "docker-cmd-with-crond.sh"]
-

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -5,7 +5,7 @@ COPY . ./
 COPY deploy.npmrc .npmrc
 RUN yarn install && yarn build
 
-FROM node:22-alpine	as optimizer
+FROM node:22 as optimizer
 ARG GITHUB_ACCESS_TOKEN
 WORKDIR /work
 COPY . ./

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,18 +1,18 @@
-FROM node:18 as compiler
+FROM node:22 as compiler
 ARG GITHUB_ACCESS_TOKEN
 WORKDIR /work
 COPY . ./
 COPY deploy.npmrc .npmrc
 RUN yarn install && yarn build
 
-FROM node:18-alpine	as optimizer
+FROM node:22-alpine	as optimizer
 ARG GITHUB_ACCESS_TOKEN
 WORKDIR /work
 COPY . ./
 COPY deploy.npmrc .npmrc
 RUN yarn install --production --ignore-optional
 
-FROM gcr.io/distroless/nodejs:18
+FROM gcr.io/distroless/nodejs:22
 WORKDIR /usr/src/app
 COPY --from=optimizer /work/node_modules ./node_modules
 COPY --from=optimizer /work/package.json ./

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "xlsx": "^0.18.5"
   },
   "engines": {
-    "node": "18"
+    "node": "22"
   },
   "devDependencies": {
     "@types/debug": "^4.1.12",
@@ -67,7 +67,7 @@
     "@types/koa__cors": "^4.0.0",
     "@types/mime-types": "^2.1.1",
     "@types/ms": "^0.7.31",
-    "@types/node": "^18.0.0",
+    "@types/node": "^22.0.0",
     "@types/supertest": "^2.0.12",
     "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "^5.37.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,10 +1050,12 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.3.3.tgz#329842940042d2b280897150e023e604d11657d6"
   integrity sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw==
 
-"@types/node@^18.0.0":
-  version "18.16.19"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.19.tgz#cb03fca8910fdeb7595b755126a8a78144714eea"
-  integrity sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==
+"@types/node@^22.0.0":
+  version "22.19.19"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.19.19.tgz#3124bf26ded54168b768138321fef99b420c6112"
+  integrity sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==
+  dependencies:
+    undici-types "~6.21.0"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -6146,6 +6148,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 unicode-properties@^1.3.1:
   version "1.4.1"


### PR DESCRIPTION
This pull request upgrades the project from Node.js 18 to Node.js 22 across all relevant files and configurations. The update ensures the codebase uses the latest Node.js runtime and associated type definitions, which may improve performance, security, and compatibility with modern dependencies.

**Node.js version upgrade:**

* Updated the Node.js version from 18 to 22 in the following locations:
  - GitHub Actions workflow configuration (`.github/workflows/automatic-tests.yml`)
  - All build stages in `Dockerfile` and `Dockerfile.local` [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R22) [[2]](diffhunk://#diff-c4b61b6caa8ec64b5dad71df5483e4f74772ebd978e4ef9f412c213abea55d95L1-R15)
  - `package.json` `engines.node` field

**Dependency and type updates:**

* Upgraded `@types/node` from version 18 to 22 in `package.json` to match the new Node.js runtime

**Container base image updates:**

* Changed all Docker base images to use Node.js 22 and updated the distroless image reference in `Dockerfile.local` [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R22) [[2]](diffhunk://#diff-c4b61b6caa8ec64b5dad71df5483e4f74772ebd978e4ef9f412c213abea55d95L1-R15)

These changes collectively ensure the project is fully aligned with Node.js 22 for development, testing, and production environments.